### PR TITLE
Let's not lose information on satisfied controls

### DIFF
--- a/StoryLifecycle.md
+++ b/StoryLifecycle.md
@@ -28,6 +28,8 @@ Our team utilizes four swimlanes to manage our work.
 
 **Entrance**: Team members move stories/issues to the close swimlane once the work is complete (satisfy the acceptance criteria) OR stories/issues are no longer relevant or a priority.
 
+Related controls: CM-4, CM-9, CM-11, SC-18
+
 
 
 


### PR DESCRIPTION
Having these tags searchable can help during annual assessment.

## Changes proposed in this pull request:

Re-add control listing removed in prior PR

## security considerations

None
